### PR TITLE
begin precommit and cicd precommit plus readme

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,40 @@
+# name: Pre-Commit Checks
+
+# on:
+#   pull_request:
+#     branches:
+#       - main
+
+#   push:
+#     branches:
+#       - main
+
+# jobs:
+#   pre-commit:
+#     runs-on: ubuntu-latest
+
+#     steps:
+#       - name: Checkout Code
+#         uses: actions/checkout@v4
+
+#       - name: Install Pre-Commit
+#         run: pip install pre-commit
+
+#       - name: Install Terraform CLI
+#         uses: hashicorp/setup-terraform@v3
+#         with:
+#           terraform_version: latest
+
+#       - name: Install TFLint
+#         run: |
+#           curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
+#           tflint --version
+
+#       - name: Install Terraform Docs
+#         run: |
+#           wget https://github.com/terraform-docs/terraform-docs/releases/latest/download/terraform-docs-$(uname)-amd64 -O /usr/local/bin/terraform-docs
+#           chmod +x /usr/local/bin/terraform-docs
+#           terraform-docs --version
+
+#       - name: Run Pre-Commit Hooks
+#         run: pre-commit run --all-files --show-diff-on-failure

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.79.0  # Use the latest stable version
+    hooks:
+      - id: terraform_fmt   # Auto-format Terraform code
+      - id: terraform_validate  # Validate Terraform syntax
+      - id: terraform_tflint  # Lint Terraform code
+      - id: terraform_docs  # Auto-generate module documentation

--- a/README.md
+++ b/README.md
@@ -49,3 +49,31 @@ module "<module_name>" {
 | (example)instance_id | ID of the created EC2 instance |
 | (example)security_group_id | ID of the security group attached to the instance |
 | (example)public_ip | Public IP address assigned to the instance |
+
+## Using Pre-Commit Hooks
+
+This repository uses pre-commit hooks to ensure Terraform code is correctly formatted, validated, and linted before committing.
+
+### Installing Pre-Commit
+
+Ensure pre-commit is installed:
+
+```bash
+pip install pre-commit
+```
+### Setting Up Pre-Commit Hooks
+Run the following command in the repository root:
+
+```bash
+pre-commit install
+```
+This ensures the hooks run automatically before each commit.
+
+### Running Pre-Commit Manually
+To run the pre-commit checks against all files manually:
+
+```bash
+pre-commit run --all-files
+```
+
+

--- a/README.md
+++ b/README.md
@@ -37,15 +37,15 @@ module "<module_name>" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| vpc_id | ID of the VPC where resources will be created | `string` | n/a | yes |
-| subnet_ids | List of subnet IDs for resource placement | `list(string)` | n/a | yes |
-| instance_type | EC2 instance type to use | `string` | `"t3.micro"` | no |
-| tags | Map of tags to apply to all resources | `map(string)` | `{}` | no |
+| (example) vpc_id | ID of the VPC where resources will be created | `string` | n/a | yes |
+| (example) subnet_ids | List of subnet IDs for resource placement | `list(string)` | n/a | yes |
+| (example) instance_type | EC2 instance type to use | `string` | `"t3.micro"` | no |
+| (example) tags | Map of tags to apply to all resources | `map(string)` | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| instance_id | ID of the created EC2 instance |
-| security_group_id | ID of the security group attached to the instance |
-| public_ip | Public IP address assigned to the instance |
+| (example)instance_id | ID of the created EC2 instance |
+| (example)security_group_id | ID of the security group attached to the instance |
+| (example)public_ip | Public IP address assigned to the instance |


### PR DESCRIPTION
This pull request introduces a new pre-commit configuration and updates the README to include example placeholders. The most important changes include adding a pre-commit workflow, configuring pre-commit hooks for Terraform, and updating the README with example placeholders for better documentation.

### Pre-commit configuration:

* [`.github/workflows/pre-commit.yml`](diffhunk://#diff-ac5eead3f3ce4863c524fff031a87b7aecccb4a0493df087a4e1c704a1505036R1-R40): Added a new GitHub Actions workflow for pre-commit checks, including steps to install necessary tools and run pre-commit hooks.
* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9R1-R8): Configured pre-commit hooks for Terraform, including formatting, validation, linting, and documentation generation.

### Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L40-R51): Updated the module documentation to include example placeholders for input variables and outputs, improving clarity and consistency.